### PR TITLE
Feature/save load

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ edition = "2018"
 
 [dependencies]
 rand = "0.7.3"
+uuid = { version = "0.8", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ edition = "2018"
 [dependencies]
 rand = "0.7.3"
 uuid = { version = "0.8", features = ["v4"] }
+serde = { version = "1.0", features = ["derive"] }
+ron = "0.6.0"

--- a/src/chip/buttons.rs
+++ b/src/chip/buttons.rs
@@ -16,6 +16,7 @@ use std::rc::Rc;
 /// ```
 #[derive(Debug)]
 pub struct Button {
+    uuid: u128,
     pin: [Rc<RefCell<Pin>>; 2],
     down: bool
 }
@@ -30,10 +31,12 @@ impl Button {
     pub const OUT: u8 = 2;
 
     pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4().as_u128();
         Button {
+            uuid,
             pin: [
-                Rc::new(RefCell::new(Pin::new(1, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(2, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 1, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 2, PinType::Output))),
             ],
             down: false
         }
@@ -48,6 +51,10 @@ impl Button {
     }
 }
 impl Chip for Button {
+    fn get_uuid(&self) -> u128 {
+        self.uuid
+    }
+    
     fn get_pin_qty(&self) -> u8 { 
         2
     }

--- a/src/chip/buttons.rs
+++ b/src/chip/buttons.rs
@@ -1,5 +1,6 @@
 //! Buttons and other physically interactable chips
-use super::super::State;
+use crate::save::SavedChip;
+use crate::State;
 use super::{Pin, PinType, Chip};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -54,7 +55,9 @@ impl Chip for Button {
     fn get_uuid(&self) -> u128 {
         self.uuid
     }
-    
+    fn get_type(&self) -> &str {
+        "virt_ic::Button"
+    }
     fn get_pin_qty(&self) -> u8 { 
         2
     }
@@ -68,9 +71,22 @@ impl Chip for Button {
     }
     fn run(&mut self, _: std::time::Duration) {
         if self.down {
-            self.pin[1].borrow_mut().state = self.pin[0].borrow().state;
+            self.pin[1].borrow_mut().state = self.pin[0].borrow().state.clone();
         } else {
             self.pin[1].borrow_mut().state = State::Undefined;
         }
+    }
+
+    fn save(&self) -> SavedChip {
+        SavedChip {
+            uuid: self.uuid,
+            chip_type: String::from(self.get_type()),
+            chip_data: vec![
+                String::from(if self.down {"DOWN"} else {"UP"}),
+            ]
+        }
+    }
+    fn load(&mut self, s_chip: &SavedChip) {
+        self.down = s_chip.chip_data[0] == "DOWN";
     }
 }

--- a/src/chip/buttons.rs
+++ b/src/chip/buttons.rs
@@ -1,5 +1,4 @@
 //! Buttons and other physically interactable chips
-use crate::save::SavedChip;
 use crate::State;
 use super::{Pin, PinType, Chip};
 use std::cell::RefCell;
@@ -77,16 +76,12 @@ impl Chip for Button {
         }
     }
 
-    fn save(&self) -> SavedChip {
-        SavedChip {
-            uuid: self.uuid,
-            chip_type: String::from(self.get_type()),
-            chip_data: vec![
-                String::from(if self.down {"DOWN"} else {"UP"}),
-            ]
-        }
+    fn save_data(&self) -> Vec<String> {
+        vec![
+            String::from(if self.down {"DOWN"} else {"UP"}),
+        ]
     }
-    fn load(&mut self, s_chip: &SavedChip) {
-        self.down = s_chip.chip_data[0] == "DOWN";
+    fn load_data(&mut self, chip_data: &[String]) {
+        self.down = chip_data[0] == "DOWN";
     }
 }

--- a/src/chip/clocks.rs
+++ b/src/chip/clocks.rs
@@ -1,5 +1,4 @@
 //! Clocks that pulse at different speeds
-use crate::save::SavedChip;
 use crate::State;
 use super::{Pin, PinType, Chip};
 use std::cell::RefCell;
@@ -86,19 +85,15 @@ impl Chip for Clock100Hz {
         }
     }
 
-    fn save(&self) -> SavedChip {
-        SavedChip {
-            uuid: self.uuid,
-            chip_type: String::from(self.get_type()),
-            chip_data: vec![
-                String::from(if self.active {"ON"} else {"OFF"}),
-                ron::to_string(&self.timer).unwrap()
-            ]
-        }
+    fn save_data(&self) -> Vec<String> {
+        vec![
+            String::from(if self.active {"ON"} else {"OFF"}),
+            ron::to_string(&self.timer).unwrap()
+        ]
     }
-    fn load(&mut self, s_chip: &SavedChip) {
-        let timer: Duration = ron::from_str(&s_chip.chip_data[1]).unwrap();
-        self.active = s_chip.chip_data[0] == "ON";
+    fn load_data(&mut self, chip_data: &[String]) {
+        let timer: Duration = ron::from_str(&chip_data[1]).unwrap();
+        self.active = chip_data[0] == "ON";
         self.timer = timer;
     }
 }
@@ -183,19 +178,15 @@ impl Chip for Clock1kHz {
         }
     }
     
-    fn save(&self) -> SavedChip {
-        SavedChip {
-            uuid: self.uuid,
-            chip_type: String::from(self.get_type()),
-            chip_data: vec![
-                String::from(if self.active {"ON"} else {"OFF"}),
-                ron::to_string(&self.timer).unwrap()
-            ]
-        }
+    fn save_data(&self) -> Vec<String> {
+        vec![
+            String::from(if self.active {"ON"} else {"OFF"}),
+            ron::to_string(&self.timer).unwrap()
+        ]
     }
-    fn load(&mut self, s_chip: &SavedChip) {
-        let timer: Duration = ron::from_str(&s_chip.chip_data[1]).unwrap();
-        self.active = s_chip.chip_data[0] == "ON";
+    fn load_data(&mut self, chip_data: &[String]) {
+        let timer: Duration = ron::from_str(&chip_data[1]).unwrap();
+        self.active = chip_data[0] == "ON";
         self.timer = timer;
     }
 }

--- a/src/chip/clocks.rs
+++ b/src/chip/clocks.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 /// ```
 #[derive(Debug)]
 pub struct Clock100Hz {
+    uuid: u128,
     pin: [Rc<RefCell<Pin>>; 4],
     timer: Duration,
     active: bool
@@ -31,12 +32,14 @@ impl Clock100Hz {
     pub const GND: u8 = 2;
 
     pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4().as_u128();
         Clock100Hz {
+            uuid,
             pin: [
-                Rc::new(RefCell::new(Pin::new(1, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(2, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(3, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(4, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 1, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 2, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 3, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 4, PinType::Input))),
             ],
             timer: Duration::new(0,0),
             active: false,
@@ -44,6 +47,10 @@ impl Clock100Hz {
     }
 }
 impl Chip for Clock100Hz {
+    fn get_uuid(&self) -> u128 {
+        self.uuid
+    }
+
     fn get_pin_qty(&self) -> u8 { 
         4
     }
@@ -61,7 +68,86 @@ impl Chip for Clock100Hz {
             self.pin[0].borrow_mut().state = State::Low;
         } 
         // check alimented
-        static LIMIT: Duration = Duration::from_millis(10);
+        const LIMIT: Duration = Duration::from_millis(10);
+        if self.pin[1].borrow().state == State::Low && self.pin[3].borrow().state == State::High {
+            self.timer += time_elapsed;
+            if self.timer > LIMIT {
+                while self.timer > LIMIT {
+                    self.timer -= LIMIT;
+                }
+                self.active = true;
+                self.pin[0].borrow_mut().state = State::High;
+            }
+        } else {
+            self.timer = Duration::new(0,0);
+        }
+    }
+}
+
+/// A 1 kHz simple clock
+/// CLK: clock
+/// ```
+///        --------
+///  CLK --|1    4|-- VCC
+///  GND --|2    3|-- UNUSED
+///        --------
+/// ```
+#[derive(Debug)]
+pub struct Clock1kHz {
+    uuid: u128,
+    pin: [Rc<RefCell<Pin>>; 4],
+    timer: Duration,
+    active: bool
+}
+impl Default for Clock1kHz {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clock1kHz {
+    pub const CLK: u8 = 1;
+    pub const VCC: u8 = 4;
+    pub const GND: u8 = 2;
+
+    pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4().as_u128();
+        Clock1kHz {
+            uuid,
+            pin: [
+                Rc::new(RefCell::new(Pin::new(uuid, 1, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 2, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 3, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 4, PinType::Input))),
+            ],
+            timer: Duration::new(0,0),
+            active: false,
+        }
+    }
+}
+impl Chip for Clock1kHz {
+    fn get_uuid(&self) -> u128 {
+        self.uuid
+    }
+    
+    fn get_pin_qty(&self) -> u8 { 
+        4
+    }
+
+    fn get_pin(&mut self, pin: u8) -> Result<Rc<RefCell<Pin>>, &str> { 
+        if pin > 0 && pin <= 4 {
+            Ok(self.pin[pin as usize-1].clone())
+        } else {
+            Err("Pin out of bounds")
+        }
+    }
+    fn run(&mut self, time_elapsed: std::time::Duration) {
+        if self.active {
+            self.active = false;
+            self.pin[0].borrow_mut().state = State::Low;
+        } 
+        // check alimented
+        const LIMIT: Duration = Duration::from_millis(1);
         if self.pin[1].borrow().state == State::Low && self.pin[3].borrow().state == State::High {
             self.timer += time_elapsed;
             if self.timer > LIMIT {

--- a/src/chip/clocks.rs
+++ b/src/chip/clocks.rs
@@ -1,5 +1,6 @@
 //! Clocks that pulse at different speeds
-use super::super::State;
+use crate::save::SavedChip;
+use crate::State;
 use super::{Pin, PinType, Chip};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -50,7 +51,9 @@ impl Chip for Clock100Hz {
     fn get_uuid(&self) -> u128 {
         self.uuid
     }
-
+    fn get_type(&self) -> &str {
+        "virt_ic::Clock100Hz"
+    }
     fn get_pin_qty(&self) -> u8 { 
         4
     }
@@ -81,6 +84,22 @@ impl Chip for Clock100Hz {
         } else {
             self.timer = Duration::new(0,0);
         }
+    }
+
+    fn save(&self) -> SavedChip {
+        SavedChip {
+            uuid: self.uuid,
+            chip_type: String::from(self.get_type()),
+            chip_data: vec![
+                String::from(if self.active {"ON"} else {"OFF"}),
+                ron::to_string(&self.timer).unwrap()
+            ]
+        }
+    }
+    fn load(&mut self, s_chip: &SavedChip) {
+        let timer: Duration = ron::from_str(&s_chip.chip_data[1]).unwrap();
+        self.active = s_chip.chip_data[0] == "ON";
+        self.timer = timer;
     }
 }
 
@@ -129,7 +148,9 @@ impl Chip for Clock1kHz {
     fn get_uuid(&self) -> u128 {
         self.uuid
     }
-    
+    fn get_type(&self) -> &str {
+        "virt_ic::Clock1kHz"
+    }
     fn get_pin_qty(&self) -> u8 { 
         4
     }
@@ -160,5 +181,21 @@ impl Chip for Clock1kHz {
         } else {
             self.timer = Duration::new(0,0);
         }
+    }
+    
+    fn save(&self) -> SavedChip {
+        SavedChip {
+            uuid: self.uuid,
+            chip_type: String::from(self.get_type()),
+            chip_data: vec![
+                String::from(if self.active {"ON"} else {"OFF"}),
+                ron::to_string(&self.timer).unwrap()
+            ]
+        }
+    }
+    fn load(&mut self, s_chip: &SavedChip) {
+        let timer: Duration = ron::from_str(&s_chip.chip_data[1]).unwrap();
+        self.active = s_chip.chip_data[0] == "ON";
+        self.timer = timer;
     }
 }

--- a/src/chip/cpu.rs
+++ b/src/chip/cpu.rs
@@ -1,5 +1,4 @@
 //! Central Processing Units
-use crate::save::SavedChip;
 use crate::State;
 use super::{Pin, PinType, Chip};
 use std::cell::RefCell;
@@ -944,23 +943,19 @@ impl Chip for SimpleCPU {
         }
     }
 
-    fn save(&self) -> SavedChip {
-        SavedChip {
-            uuid: self.uuid,
-            chip_type: String::from(self.get_type()),
-            chip_data: vec![
-                ron::to_string(&(self.accumulator, self.reg_b, self.reg_c, self.reg_h, self.reg_l)).unwrap(),
-                ron::to_string(&(self.flag_zero, self.flag_neg, self.flag_carry, self.flag_overflow)).unwrap(),
-                ron::to_string(&(self.program_counter, self.stack_bank, self.stack_pointer, self.current_opcode, self.param_first, self.param_second)).unwrap(),
-                ron::to_string(&(self.microcode_state, self.executing, self.initializing, self.halted)).unwrap()
-            ]
-        }
+    fn save_data(&self) -> Vec<String> {
+        vec![
+            ron::to_string(&(self.accumulator, self.reg_b, self.reg_c, self.reg_h, self.reg_l)).unwrap(),
+            ron::to_string(&(self.flag_zero, self.flag_neg, self.flag_carry, self.flag_overflow)).unwrap(),
+            ron::to_string(&(self.program_counter, self.stack_bank, self.stack_pointer, self.current_opcode, self.param_first, self.param_second)).unwrap(),
+            ron::to_string(&(self.microcode_state, self.executing, self.initializing, self.halted)).unwrap()
+        ]
     }
-    fn load(&mut self, s_chip: &SavedChip) {
-        let registers: (u8, u8, u8, u8, u8) = ron::from_str(&s_chip.chip_data[0]).unwrap();
-        let flags: (bool, bool, bool, bool) = ron::from_str(&s_chip.chip_data[1]).unwrap();
-        let exec: (u16, u8, u8, u8, u8, u8) = ron::from_str(&s_chip.chip_data[2]).unwrap();
-        let internal:(u8, bool, bool, bool) = ron::from_str(&s_chip.chip_data[3]).unwrap();
+    fn load_data(&mut self, chip_data: &[String]) {
+        let registers: (u8, u8, u8, u8, u8) = ron::from_str(&chip_data[0]).unwrap();
+        let flags: (bool, bool, bool, bool) = ron::from_str(&chip_data[1]).unwrap();
+        let exec: (u16, u8, u8, u8, u8, u8) = ron::from_str(&chip_data[2]).unwrap();
+        let internal:(u8, bool, bool, bool) = ron::from_str(&chip_data[3]).unwrap();
         
         self.accumulator = registers.0;
         self.reg_b = registers.1;

--- a/src/chip/cpu.rs
+++ b/src/chip/cpu.rs
@@ -143,6 +143,7 @@ use std::rc::Rc;
 ///        --------
 /// ```
 pub struct SimpleCPU {
+    uuid: u128,
     pin: [Rc<RefCell<Pin>>; 26],
     program_counter: u16,
     accumulator: u8,
@@ -205,34 +206,36 @@ impl SimpleCPU {
     pub const GND: u8 = 13;
 
     pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4().as_u128();
         SimpleCPU {
+            uuid,
             pin: [
-                Rc::new(RefCell::new(Pin::new(1, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(2, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(3, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(4, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(5, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(6, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(7, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(8, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(9, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(10, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(11, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(12, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(13, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(14, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(15, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(16, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(17, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(18, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(19, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(20, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(21, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(22, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(23, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(24, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(25, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(26, PinType::Input)))
+                Rc::new(RefCell::new(Pin::new(uuid, 1, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 2, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 3, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 4, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 5, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 6, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 7, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 8, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 9, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 10, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 11, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 12, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 13, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 14, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 15, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 16, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 17, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 18, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 19, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 20, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 21, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 22, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 23, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 24, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 25, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 26, PinType::Input)))
             ],
             program_counter: 0,
             accumulator: 0,
@@ -844,6 +847,10 @@ impl SimpleCPU {
     }
 }
 impl Chip for SimpleCPU {
+    fn get_uuid(&self) -> u128 {
+        self.uuid
+    }
+
     fn get_pin_qty(&self) -> u8 { 
         26
     }

--- a/src/chip/gates.rs
+++ b/src/chip/gates.rs
@@ -20,6 +20,7 @@ use std::rc::Rc;
 /// ```
 #[derive(Debug)]
 pub struct GateOr {
+    uuid: u128,
     pin: [Rc<RefCell<Pin>>; 14],
 }
 impl Default for GateOr {
@@ -45,27 +46,33 @@ impl GateOr {
     pub const GND: u8 = 7;
 
     pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4().as_u128();
         GateOr {
+            uuid,
             pin: [
-                Rc::new(RefCell::new(Pin::new(1, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(2, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(3, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(4, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(5, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(6, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(7, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(8, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(9, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(10, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(11, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(12, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(13, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(14, PinType::Input)))
+                Rc::new(RefCell::new(Pin::new(uuid, 1, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 2, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 3, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 4, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 5, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 6, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 7, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 8, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 9, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 10, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 11, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 12, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 13, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 14, PinType::Input)))
             ]
         }
     }
 }
 impl Chip for GateOr {
+    fn get_uuid(&self) -> u128 {
+        self.uuid
+    }
+
     fn get_pin_qty(&self) -> u8 { 
         14
     }
@@ -114,6 +121,7 @@ impl Chip for GateOr {
 /// ```
 #[derive(Debug)]
 pub struct GateAnd {
+    uuid: u128,
     pin: [Rc<RefCell<Pin>>; 14],
 }
 impl Default for GateAnd {
@@ -139,27 +147,33 @@ impl GateAnd {
     pub const GND: u8 = 7;
 
     pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4().as_u128();
         GateAnd {
+            uuid,
             pin: [
-                Rc::new(RefCell::new(Pin::new(1, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(2, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(3, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(4, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(5, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(6, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(7, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(8, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(9, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(10, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(11, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(12, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(13, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(14, PinType::Input)))
+                Rc::new(RefCell::new(Pin::new(uuid, 1, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 2, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 3, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 4, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 5, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 6, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 7, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 8, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 9, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 10, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 11, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 12, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 13, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 14, PinType::Input)))
             ]
         }
     }
 }
 impl Chip for GateAnd {
+    fn get_uuid(&self) -> u128 {
+        self.uuid
+    }
+
     fn get_pin_qty(&self) -> u8 { 
         14
     }
@@ -207,6 +221,7 @@ impl Chip for GateAnd {
 /// ```
 #[derive(Debug)]
 pub struct GateNot {
+    uuid: u128,
     pin: [Rc<RefCell<Pin>>; 14],
 }
 impl Default for GateNot {
@@ -232,27 +247,33 @@ impl GateNot {
     pub const GND: u8 = 7;
 
     pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4().as_u128();
         GateNot {
+            uuid,
             pin: [
-                Rc::new(RefCell::new(Pin::new(1, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(2, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(3, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(4, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(5, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(6, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(7, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(8, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(9, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(10, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(11, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(12, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(13, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(14, PinType::Input)))
+                Rc::new(RefCell::new(Pin::new(uuid, 1, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 2, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 3, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 4, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 5, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 6, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 7, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 8, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 9, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 10, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 11, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 12, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 13, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 14, PinType::Input)))
             ]
         }
     }
 }
 impl Chip for GateNot {
+    fn get_uuid(&self) -> u128 {
+        self.uuid
+    }
+
     fn get_pin_qty(&self) -> u8 { 
         14
     }

--- a/src/chip/gates.rs
+++ b/src/chip/gates.rs
@@ -1,5 +1,6 @@
 //! Logic Gates like OR, AND, NOT ...
-use super::super::State;
+use crate::save::SavedChip;
+use crate::State;
 use super::{Pin, PinType, Chip};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -72,7 +73,9 @@ impl Chip for GateOr {
     fn get_uuid(&self) -> u128 {
         self.uuid
     }
-
+    fn get_type(&self) -> &str {
+        "virt_ic::GateOr"
+    }
     fn get_pin_qty(&self) -> u8 { 
         14
     }
@@ -102,6 +105,15 @@ impl Chip for GateOr {
             }
         }
     }
+
+    fn save(&self) -> SavedChip {
+        SavedChip {
+            uuid: self.uuid,
+            chip_type: String::from(self.get_type()),
+            chip_data: vec![]
+        }
+    }
+    fn load(&mut self, _s_chip: &SavedChip) {}
 }
 
 
@@ -173,7 +185,9 @@ impl Chip for GateAnd {
     fn get_uuid(&self) -> u128 {
         self.uuid
     }
-
+    fn get_type(&self) -> &str {
+        "virt_ic::GateAnd"
+    }
     fn get_pin_qty(&self) -> u8 { 
         14
     }
@@ -203,6 +217,15 @@ impl Chip for GateAnd {
             }
         }
     }
+
+    fn save(&self) -> SavedChip {
+        SavedChip {
+            uuid: self.uuid,
+            chip_type: String::from(self.get_type()),
+            chip_data: vec![]
+        }
+    }
+    fn load(&mut self, _s_chip: &SavedChip) {}
 }
 
 /// # A chip with 6 bundled "NOT" gates
@@ -273,7 +296,9 @@ impl Chip for GateNot {
     fn get_uuid(&self) -> u128 {
         self.uuid
     }
-
+    fn get_type(&self) -> &str {
+        "virt_ic::GateNot"
+    }
     fn get_pin_qty(&self) -> u8 { 
         14
     }
@@ -307,4 +332,13 @@ impl Chip for GateNot {
             }
         }
     }
+
+    fn save(&self) -> SavedChip {
+        SavedChip {
+            uuid: self.uuid,
+            chip_type: String::from(self.get_type()),
+            chip_data: vec![]
+        }
+    }
+    fn load(&mut self, _s_chip: &SavedChip) {}
 }

--- a/src/chip/gates.rs
+++ b/src/chip/gates.rs
@@ -1,5 +1,4 @@
 //! Logic Gates like OR, AND, NOT ...
-use crate::save::SavedChip;
 use crate::State;
 use super::{Pin, PinType, Chip};
 use std::cell::RefCell;
@@ -105,15 +104,6 @@ impl Chip for GateOr {
             }
         }
     }
-
-    fn save(&self) -> SavedChip {
-        SavedChip {
-            uuid: self.uuid,
-            chip_type: String::from(self.get_type()),
-            chip_data: vec![]
-        }
-    }
-    fn load(&mut self, _s_chip: &SavedChip) {}
 }
 
 
@@ -217,15 +207,6 @@ impl Chip for GateAnd {
             }
         }
     }
-
-    fn save(&self) -> SavedChip {
-        SavedChip {
-            uuid: self.uuid,
-            chip_type: String::from(self.get_type()),
-            chip_data: vec![]
-        }
-    }
-    fn load(&mut self, _s_chip: &SavedChip) {}
 }
 
 /// # A chip with 6 bundled "NOT" gates
@@ -332,13 +313,4 @@ impl Chip for GateNot {
             }
         }
     }
-
-    fn save(&self) -> SavedChip {
-        SavedChip {
-            uuid: self.uuid,
-            chip_type: String::from(self.get_type()),
-            chip_data: vec![]
-        }
-    }
-    fn load(&mut self, _s_chip: &SavedChip) {}
 }

--- a/src/chip/generators.rs
+++ b/src/chip/generators.rs
@@ -1,5 +1,6 @@
 //! Generators that provide fixed currents
-use super::super::State;
+use crate::save::SavedChip;
+use crate::State;
 use super::{Pin, PinType, Chip};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -45,7 +46,9 @@ impl Chip for Generator {
     fn get_uuid(&self) -> u128 {
         self.uuid
     } 
-
+    fn get_type(&self) -> &str {
+        "virt_ic::Generator"
+    }
     fn get_pin_qty(&self) -> u8 { 
         2
     }
@@ -61,4 +64,14 @@ impl Chip for Generator {
         self.pin[0].borrow_mut().state = State::High;
         self.pin[1].borrow_mut().state = State::Low;
     }
+
+    fn save(&self) -> SavedChip {
+        SavedChip {
+            uuid: self.uuid,
+            chip_type: String::from(self.get_type()),
+            chip_data: vec![]
+        }
+    }
+
+    fn load(&mut self, _s_chip: &SavedChip) {}
 }

--- a/src/chip/generators.rs
+++ b/src/chip/generators.rs
@@ -14,6 +14,7 @@ use std::rc::Rc;
 /// ```
 #[derive(Debug)]
 pub struct Generator {
+    uuid: u128,
     pin: [Rc<RefCell<Pin>>; 2],
 }
 impl Default for Generator {
@@ -27,10 +28,12 @@ impl Generator {
     pub const GND: u8 = 2;
     
     pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4().as_u128();
         let gen = Generator {
+            uuid,
             pin: [
-                Rc::new(RefCell::new(Pin::new(1, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(2, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 1, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 2, PinType::Output))),
             ]
         };
         gen.pin[0].borrow_mut().state = State::High;
@@ -39,6 +42,10 @@ impl Generator {
     }
 }
 impl Chip for Generator {
+    fn get_uuid(&self) -> u128 {
+        self.uuid
+    } 
+
     fn get_pin_qty(&self) -> u8 { 
         2
     }

--- a/src/chip/generators.rs
+++ b/src/chip/generators.rs
@@ -1,5 +1,4 @@
 //! Generators that provide fixed currents
-use crate::save::SavedChip;
 use crate::State;
 use super::{Pin, PinType, Chip};
 use std::cell::RefCell;
@@ -64,14 +63,4 @@ impl Chip for Generator {
         self.pin[0].borrow_mut().state = State::High;
         self.pin[1].borrow_mut().state = State::Low;
     }
-
-    fn save(&self) -> SavedChip {
-        SavedChip {
-            uuid: self.uuid,
-            chip_type: String::from(self.get_type()),
-            chip_data: vec![]
-        }
-    }
-
-    fn load(&mut self, _s_chip: &SavedChip) {}
 }

--- a/src/chip/memory.rs
+++ b/src/chip/memory.rs
@@ -1,5 +1,4 @@
 //! Readable and/or Writable Memory Chips
-use crate::save::SavedChip;
 use crate::State;
 use super::{Pin, PinType, Chip};
 use std::cell::RefCell;
@@ -215,20 +214,16 @@ impl Chip for Ram256B {
         }
     }
 
-    fn save(&self) -> SavedChip {
-        SavedChip {
-            uuid: self.uuid,
-            chip_type: String::from(self.get_type()),
-            chip_data: vec![
-                ron::to_string(&self.ram.to_vec()).unwrap(),
-                String::from(if self.powered {"ON"} else {"OFF"})
-            ]
-        }
+    fn save_data(&self) -> Vec<String> {
+        vec![
+            ron::to_string(&self.ram.to_vec()).unwrap(),
+            String::from(if self.powered {"ON"} else {"OFF"})
+        ]
     }
-    fn load(&mut self, s_chip: &SavedChip) {
-        let data: Vec<u8> = ron::from_str(&s_chip.chip_data[0]).unwrap();
+    fn load_data(&mut self, chip_data: &[String]) {
+        let data: Vec<u8> = ron::from_str(&chip_data[0]).unwrap();
         self.ram.copy_from_slice(&data[..data.len()]);
-        self.powered = s_chip.chip_data[1] == "ON";
+        self.powered = chip_data[1] == "ON";
     }
 }
 
@@ -418,17 +413,13 @@ impl Chip for Rom256B {
         }
     }
 
-    fn save(&self) -> SavedChip {
-        SavedChip {
-            uuid: self.uuid,
-            chip_type: String::from(self.get_type()),
-            chip_data: vec![
-                ron::to_string(&self.rom.to_vec()).unwrap()
-            ]
-        }
+    fn save_data(&self) -> Vec<String> {
+        vec![
+            ron::to_string(&self.rom.to_vec()).unwrap()
+        ]
     }
-    fn load(&mut self, s_chip: &SavedChip) {
-        let data: Vec<u8> = ron::from_str(&s_chip.chip_data[0]).unwrap();
+    fn load_data(&mut self, chip_data: &[String]) {
+        let data: Vec<u8> = ron::from_str(&chip_data[0]).unwrap();
         self.rom.copy_from_slice(&data[..data.len()]);
     }
 }

--- a/src/chip/memory.rs
+++ b/src/chip/memory.rs
@@ -29,6 +29,7 @@ use rand::random;
 ///        --------
 /// ```
 pub struct Ram256B {
+    uuid: u128,
     pin: [Rc<RefCell<Pin>>; 22],
     ram: [u8; 256],
     powered: bool
@@ -84,30 +85,32 @@ impl Ram256B {
     pub const GND: u8 = 11;
     
     pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4().as_u128();
         Ram256B {
+            uuid,
             pin: [
-                Rc::new(RefCell::new(Pin::new(1, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(2, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(3, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(4, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(5, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(6, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(7, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(8, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(9, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(10, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(11, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(12, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(13, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(14, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(15, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(16, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(17, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(18, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(19, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(20, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(21, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(22, PinType::Input)))
+                Rc::new(RefCell::new(Pin::new(uuid, 1, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 2, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 3, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 4, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 5, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 6, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 7, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 8, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 9, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 10, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 11, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 12, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 13, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 14, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 15, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 16, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 17, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 18, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 19, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 20, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 21, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 22, PinType::Input)))
             ],
             ram: [0; 256],
             powered: false
@@ -135,6 +138,10 @@ impl Ram256B {
     }
 }
 impl Chip for Ram256B {
+    fn get_uuid(&self) -> u128 {
+        self.uuid
+    }
+
     fn get_pin_qty(&self) -> u8 { 
         22
     }
@@ -229,6 +236,7 @@ impl Chip for Ram256B {
 ///         --------
 /// ```
 pub struct Rom256B {
+    uuid: u128,
     pin: [Rc<RefCell<Pin>>; 22],
     rom: [u8; 256],
 }
@@ -281,30 +289,32 @@ impl Rom256B {
     pub const GND: u8 = 11;
 
     pub fn new() -> Self {
+        let uuid = uuid::Uuid::new_v4().as_u128();
         Rom256B {
+            uuid,
             pin: [
-                Rc::new(RefCell::new(Pin::new(1, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(2, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(3, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(4, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(5, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(6, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(7, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(8, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(9, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(10, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(11, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(12, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(13, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(14, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(15, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(16, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(17, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(18, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(19, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(20, PinType::Output))),
-                Rc::new(RefCell::new(Pin::new(21, PinType::Input))),
-                Rc::new(RefCell::new(Pin::new(22, PinType::Input)))
+                Rc::new(RefCell::new(Pin::new(uuid, 1, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 2, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 3, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 4, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 5, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 6, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 7, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 8, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 9, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 10, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 11, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 12, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 13, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 14, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 15, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 16, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 17, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 18, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 19, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 20, PinType::Output))),
+                Rc::new(RefCell::new(Pin::new(uuid, 21, PinType::Input))),
+                Rc::new(RefCell::new(Pin::new(uuid, 22, PinType::Input)))
             ],
             rom: [0; 256],
         }
@@ -332,6 +342,10 @@ impl Rom256B {
     }
 }
 impl Chip for Rom256B {
+    fn get_uuid(&self) -> u128 {
+        self.uuid
+    }
+
     fn get_pin_qty(&self) -> u8 { 
         22
     }

--- a/src/chip/mod.rs
+++ b/src/chip/mod.rs
@@ -64,9 +64,23 @@ pub trait Chip: std::fmt::Debug {
         } 
     }
 
-    fn save(&self) -> SavedChip;
+    fn save(&self) -> SavedChip {
+        SavedChip {
+            uuid: self.get_uuid(),
+            chip_type: String::from(self.get_type()),
+            chip_data: self.save_data()
+        }
+    }
 
-    fn load(&mut self, saved_chip: &SavedChip);
+    fn save_data(&self) -> Vec<String> {
+        vec![]
+    }
+
+    fn load(&mut self, saved_chip: &SavedChip) {
+        self.load_data(&saved_chip.chip_data);
+    }
+
+    fn load_data(&mut self, _chip_data: &[String]) {}
 }
 
 pub fn virt_ic_chip_factory(chip_name: &str) -> Option<Box<dyn Chip>> {

--- a/src/chip/mod.rs
+++ b/src/chip/mod.rs
@@ -1,5 +1,6 @@
 //! Chip trait, Pins and premade Chips
 use super::State;
+pub mod buttons;
 pub mod gates;
 pub mod generators;
 pub mod memory;
@@ -7,9 +8,11 @@ pub mod cpu;
 pub mod clocks;
 use std::cell::RefCell;
 use std::rc::Rc;
+use serde::{Serialize, Deserialize};
+use super::save::SavedChip;
 
 /// The type of a Pin, that can be Input or Output
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum PinType {
     Undefined,
     Input,
@@ -18,7 +21,7 @@ pub enum PinType {
 }
 
 /// A chip's Pin. Can be of type Input or Output, and holds a State
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Pin {
     pub parent: u128,
     pub number: u8,
@@ -39,6 +42,7 @@ impl Pin {
 /// Chip : a trait that represents chips on board
 pub trait Chip: std::fmt::Debug {
     fn get_uuid(&self) -> u128;
+    fn get_type(&self) -> &str;
     /// Runs the chip for a certain amount of time
     fn run(&mut self, elapsed_time: std::time::Duration);
     /// Returns the number of pins the chip has
@@ -58,5 +62,25 @@ pub trait Chip: std::fmt::Debug {
         if let Ok(pin) = self.get_pin(pin) {
             pin.borrow_mut().state = state.clone();
         } 
+    }
+
+    fn save(&self) -> SavedChip;
+
+    fn load(&mut self, saved_chip: &SavedChip);
+}
+
+pub fn virt_ic_chip_factory(chip_name: &str) -> Option<Box<dyn Chip>> {
+    match chip_name {
+        "virt_ic::Button" => Some(Box::new(buttons::Button::new())),
+        "virt_ic::Clock100Hz" => Some(Box::new(clocks::Clock100Hz::new())),
+        "virt_ic::Clock1kHz" => Some(Box::new(clocks::Clock1kHz::new())),
+        "virt_ic::SimpleCPU" => Some(Box::new(cpu::SimpleCPU::new())),
+        "virt_ic::GateOr" => Some(Box::new(gates::GateOr::new())),
+        "virt_ic::GateAnd" => Some(Box::new(gates::GateAnd::new())),
+        "virt_ic::GateNot" => Some(Box::new(gates::GateNot::new())),
+        "virt_ic::Generator" => Some(Box::new(generators::Generator::new())),
+        "virt_ic::Ram256B" => Some(Box::new(memory::Ram256B::new())),
+        "virt_ic::Rom256B" => Some(Box::new(memory::Rom256B::new())),
+        _ => None
     }
 }

--- a/src/chip/mod.rs
+++ b/src/chip/mod.rs
@@ -20,13 +20,15 @@ pub enum PinType {
 /// A chip's Pin. Can be of type Input or Output, and holds a State
 #[derive(Debug)]
 pub struct Pin {
+    pub parent: u128,
     pub number: u8,
     pub pin_type: PinType,
     pub state: State,
 }
 impl Pin {
-    pub fn new(number: u8, pin_type: PinType) -> Pin {
+    pub fn new(parent_uuid: u128, number: u8, pin_type: PinType) -> Pin {
         Pin {
+            parent: parent_uuid,
             number,
             pin_type,
             state: State::Undefined
@@ -36,6 +38,7 @@ impl Pin {
 
 /// Chip : a trait that represents chips on board
 pub trait Chip: std::fmt::Debug {
+    fn get_uuid(&self) -> u128;
     /// Runs the chip for a certain amount of time
     fn run(&mut self, elapsed_time: std::time::Duration);
     /// Returns the number of pins the chip has

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,15 @@ pub mod chip;
 mod trace;
 mod board;
 mod socket;
+mod save;
 pub use chip::{Chip, Pin, PinType};
 pub use board::Board;
 pub use trace::Trace;
 pub use socket::Socket;
+use serde::{Serialize, Deserialize};
 
 /// Current's State
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum State {
     Undefined,
     High,

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,0 +1,95 @@
+use serde::{Serialize, Deserialize};
+use super::{Pin, Board, Chip, Socket};
+use std::rc::Rc;
+use std::cell::RefCell;
+
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SavedChip {
+    pub uuid: u128,
+    pub chip_type: String,
+    pub chip_data: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SavedSocket {
+    pub chip: Option<SavedChip>
+}
+impl SavedSocket {
+    pub fn new() -> SavedSocket {
+        SavedSocket {
+            chip: None
+        }
+    }
+    pub fn set_chip(&mut self, chip: SavedChip) {
+        self.chip = Some(chip)
+    }
+}
+
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct SavedTrace {
+    pub pins: Vec<Pin>
+}
+impl SavedTrace {
+    pub fn new() -> SavedTrace {
+        SavedTrace {
+            pins: vec![]
+        }
+    }
+
+    pub fn add_trace(&mut self, pin: Pin) {
+        self.pins.push(pin);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SavedBoard {
+    sockets: Vec<SavedSocket>,
+    traces: Vec<SavedTrace>
+}
+
+impl SavedBoard {
+    pub fn new() -> Self {
+        SavedBoard{
+            sockets: vec![],
+            traces: vec![]
+        }
+    }
+    pub fn add_trace(&mut self, trace: SavedTrace) {
+        self.traces.push(trace);
+    }
+    pub fn add_socket(&mut self, socket: SavedSocket) {
+        self.sockets.push(socket);
+    }
+
+    pub fn build_board(&self, chip_factory: &dyn Fn(&str) -> Option<Box<dyn Chip>>) -> Board {
+        let mut board = Board::new();
+        let mut loaded_chips: Vec<(u128, Rc<RefCell<Socket>>)> = vec![];
+
+        for s_socket in self.sockets.iter() {
+            let socket = board.new_socket();
+            if let Some(s_chip) = &s_socket.chip {
+                if let Some(chip) = chip_factory(&s_chip.chip_type) {
+                    socket.borrow_mut().plug(chip);
+                    socket.borrow_mut().load(s_chip);
+                    loaded_chips.push((s_chip.uuid, socket.clone()));
+                }
+            }
+        }
+
+        for s_trace in self.traces.iter() {
+            let trace = board.new_trace();
+            for s_pin in s_trace.pins.iter() {
+                for l_chip in loaded_chips.iter() {
+                    if s_pin.parent == l_chip.0 {
+                        l_chip.1.borrow_mut().set_pin_state(s_pin.number, &s_pin.state);
+                        l_chip.1.borrow_mut().get_pin(s_pin.number).unwrap().borrow_mut().pin_type = s_pin.pin_type.clone();
+                        trace.borrow_mut().connect(l_chip.1.borrow_mut().get_pin(s_pin.number).unwrap().clone())
+                    }
+                }
+            }
+        }
+        board
+    }
+}

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,4 +1,4 @@
-use super::{Chip, Pin, PinType, State};
+use super::{Chip, Pin, PinType, State, save::SavedChip};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -62,6 +62,13 @@ impl Chip for Socket {
             0
         }
     }
+    fn get_type(&self) -> &str {
+        if let Some(chip) = self.chip.as_ref() {
+            chip.get_type()
+        } else {
+            "NULL"
+        }
+    }
 
     fn get_pin_qty(&self) -> u8 {
         if let Some(chip) = self.chip.as_ref() {
@@ -102,6 +109,22 @@ impl Chip for Socket {
     fn run(&mut self, elapsed_time: std::time::Duration) {
         if let Some(chip) = self.chip.as_mut() {
             chip.run(elapsed_time)
+        }
+    }
+    fn save(&self) -> SavedChip {
+        if let Some(chip) = self.chip.as_ref() {
+            chip.save()
+        } else {
+            SavedChip {
+                uuid: uuid::Uuid::new_v4().as_u128(),
+                chip_type: String::from("NULL"),
+                chip_data: vec![]
+            }
+        }
+    }
+    fn load(&mut self, s_chip: &SavedChip) {
+        if let Some(chip) = self.chip.as_mut() {
+            chip.load(s_chip);
         }
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,4 +1,4 @@
-use super::{Chip, Pin, PinType, State, save::SavedChip};
+use super::{Chip, Pin, PinType, State};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -111,20 +111,16 @@ impl Chip for Socket {
             chip.run(elapsed_time)
         }
     }
-    fn save(&self) -> SavedChip {
+    fn save_data(&self) -> Vec<String> {
         if let Some(chip) = self.chip.as_ref() {
-            chip.save()
+            chip.save_data()
         } else {
-            SavedChip {
-                uuid: uuid::Uuid::new_v4().as_u128(),
-                chip_type: String::from("NULL"),
-                chip_data: vec![]
-            }
+            vec![]
         }
     }
-    fn load(&mut self, s_chip: &SavedChip) {
+    fn load_data(&mut self, s_chip: &[String]) {
         if let Some(chip) = self.chip.as_mut() {
-            chip.load(s_chip);
+            chip.load_data(s_chip)
         }
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -55,6 +55,14 @@ impl Socket {
 }
 
 impl Chip for Socket {
+    fn get_uuid(&self) -> u128 {
+        if let Some(chip) = self.chip.as_ref() {
+            chip.get_uuid()
+        } else {
+            0
+        }
+    }
+
     fn get_pin_qty(&self) -> u8 {
         if let Some(chip) = self.chip.as_ref() {
             chip.get_pin_qty()

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,4 +1,4 @@
-use super::{Pin, PinType, State};
+use super::{Pin, PinType, State, save::SavedTrace};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -35,5 +35,13 @@ impl Trace {
                 pin.borrow_mut().state = main_state.clone();
             }
         }
+    }
+
+    pub fn save(&self) -> SavedTrace {
+        let mut save = SavedTrace::new();
+        for pin in self.link.iter() {
+            save.add_trace(pin.borrow().clone());
+        }
+        save
     }
 }


### PR DESCRIPTION
Adding `save` and `load` functions to `Board`.

In consequence, `Chip` trait now needs four new methods: 
- `get_uuid() -> u128` : Give a unique id to maintain continuity when saving. This uuid must not maintain any information other that identity. When saving, this value will be used to link the traced pins to their respective chip.
- `get_type() -> &str` : Give a unique name for the chip struct, it must be the same for every chips of the same struct. This value will be used to rebuild the correct Struct based on this name with the help of the chip factory
- `save_data() -> Vec<String>` : Create a Vec of String that must contain every information you need to restore your chip to a certain state. This will be saved in the resulting file.
- `load_data(&[String])` : Using the array of String you provided in `save_data` , you must restore the state of your chip.

Note that `save_data` and `load_data` are optional, but if you do not implement them their state won't be saved at all. Useful for "i'm doing it later" or "my chip don't need to save data".

Additionally, `Pin::new()` now require that you provide your chip's uuid as a first parameter to keep track of which chip a Pin comes from.

Board can now provide you its sockets and traces, and also give you a specific socket based on the uuid of the plugged chip